### PR TITLE
17 custom filter overwriting

### DIFF
--- a/docs/News.md
+++ b/docs/News.md
@@ -40,14 +40,6 @@ The AdGuard Home API endpoint `/control/filtering/set_rules` **replaces** the en
 - `src/app/api/set-filtering-rule/route.ts` - Complete rewrite of rule management logic
 - `docs/Custom-Filter-Rules.md` - New documentation explaining the implementation
 
-### 📚 Documentation:
-
-Detailed technical documentation has been added to `docs/Custom-Filter-Rules.md` explaining:
-- The root cause of the issue
-- Implementation details of the fix
-- Future considerations for per-client rule support
-- Testing recommendations
-
 ---
 
 **October 2, 2025 - v0.1.20251002**

--- a/docs/News.md
+++ b/docs/News.md
@@ -1,5 +1,55 @@
 # ✨ What's New in AdGuard Buddy ✨
 
+**October 8, 2025 - v0.1.20251008**
+
+## 🔧 CRITICAL FIX: Custom Filter Rules Overwriting
+
+**Important bug fix!** This release resolves a critical issue where using the unblock/block function in the query log would overwrite all existing custom filter rules.
+
+### 🐛 Issue Fixed:
+
+**Custom Filter Rules Being Overwritten** ⚠️
+- Fixed query log unblock/block function deleting all existing custom rules
+- Rules are now properly preserved when adding new block/unblock rules
+- Manual sync and auto-sync continue to work correctly
+- **Impact**: All custom filter rules are now safe when using quick block/unblock actions
+
+### 🎯 Root Cause:
+
+The AdGuard Home API endpoint `/control/filtering/set_rules` **replaces** the entire custom rules list rather than appending to it. The previous implementation was sending only the new rule, which caused all existing rules to be deleted.
+
+### ✨ Solution Implemented:
+
+**Three-Step Process:**
+1. **Fetch existing rules** - Retrieves current custom rules from the server before making changes
+2. **Intelligent merge** - Combines new rule with existing rules:
+   - Prevents duplicate rules
+   - Removes conflicting rules (e.g., removes block rule when adding unblock for same domain)
+   - Preserves all other existing rules, including comments
+3. **Update complete list** - Sends back the full set of rules to AdGuard Home
+
+### 📋 Features:
+
+- ✅ **No Data Loss** - All existing custom rules are preserved
+- ✅ **Smart Conflict Resolution** - Block and unblock rules for the same domain don't coexist
+- ✅ **Duplicate Prevention** - Won't add the same rule twice
+- ✅ **Sync-Safe** - Manual and auto-sync continue to work correctly
+- ✅ **Better Feedback** - Shows detailed progress during rule updates
+
+### 📝 Files Modified:
+- `src/app/api/set-filtering-rule/route.ts` - Complete rewrite of rule management logic
+- `docs/Custom-Filter-Rules.md` - New documentation explaining the implementation
+
+### 📚 Documentation:
+
+Detailed technical documentation has been added to `docs/Custom-Filter-Rules.md` explaining:
+- The root cause of the issue
+- Implementation details of the fix
+- Future considerations for per-client rule support
+- Testing recommendations
+
+---
+
 **October 2, 2025 - v0.1.20251002**
 
 ## 🔧 CRITICAL FIX: Connection & Sync Issues After Container Upgrade

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adguard-buddy",
-  "version": "0.1.20251002",
+  "version": "0.1.20251008",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Pull Request Summary
🔧 Critical Bug Fix: Custom Filter Rules Preservation
Problem Fixed
Fixed a critical bug where using the unblock/block function in the query log would overwrite all existing custom filter rules instead of adding to them.

## Root Cause
The AdGuard Home API endpoint /control/filtering/set_rules replaces the entire custom rules list rather than appending. The previous implementation only sent the new rule, causing all existing rules to be deleted.

## Solution Implemented
Implemented a 3-step intelligent merge process:

Fetch existing rules from AdGuard Home server
Smart merge with new rule:
Prevents duplicates
Removes conflicting rules (e.g., removes block rule when adding unblock for same domain)
Preserves all existing rules and comments
Send complete merged list back to AdGuard Home

Benefits
✅ No Data Loss - All existing custom rules are preserved
✅ Smart Conflict Resolution - Block/unblock rules for same domain don't coexist
✅ Duplicate Prevention - Won't add the same rule twice
✅ Sync-Safe - Manual and auto-sync continue to work correctly
✅ Better User Feedback - Shows detailed progress during updates

## Testing

✅ ESLint passes with no warnings
✅ Backward compatible
✅ No breaking changes
This fix ensures users can safely use the query log unblock/block functionality without losing their carefully curated custom filter rules.

